### PR TITLE
fix: page owner의 pml4 접근 시 protection interrupt 발생 문제 해결

### DIFF
--- a/vm/file.c
+++ b/vm/file.c
@@ -89,7 +89,7 @@ file_backed_swap_out(struct page *page)
 {
 	/* NOTE: swap out 구현 */
 	struct file_page *file_page = &page->file;
-	uint64_t *pml4 = thread_current()->pml4;
+	uint64_t *pml4 = page->owner->pml4;
 	void *upage = page->va;
 
 	/* 페이지가 변경되었는지 확인 */
@@ -102,7 +102,11 @@ file_backed_swap_out(struct page *page)
 		pml4_set_dirty(pml4, upage, false);
 	}
 	/* pml4에서 페이지 제거 */
+	page->frame = NULL;
+	list_remove(&page->f_elem);
 	pml4_clear_page(pml4, upage);
+
+	return true;
 }
 
 /**
@@ -115,7 +119,7 @@ static void
 file_backed_destroy(struct page *page)
 {
 	struct file_page *file_page = &page->file;
-	uint64_t *pml4 = thread_current()->pml4;
+	uint64_t *pml4 = page->owner->pml4;
 	void *upage = page->va;
 
 	/* 페이지가 변경되었는지 확인 */
@@ -129,6 +133,7 @@ file_backed_destroy(struct page *page)
 	}
 	/* pml4에서 페이지 제거 */
 	pml4_clear_page(pml4, upage);
+	list_remove(&page->f_elem);
 }
 
 /**

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -104,15 +104,13 @@ err:
 struct page *
 spt_find_page(struct supplemental_page_table *spt, void *va)
 {
-	struct page *page = malloc(sizeof(struct page)); /* page 구조체 동적 할당 */
 	struct hash_elem *e;
 
-	/* page 동적 할당 실패 시 NULL 반환 */
-	if (page == NULL)
-		PANIC("spt find page");
-	page->va = pg_round_down(va);				 /* 할당된 page 구조체의 가상 주소 설정 */
-	e = hash_find(&spt->hash, &page->hash_elem); /* spt의 해시 테이블에서 page의 hash_elem 찾기  */
-	free(page);									 /* page 구조체 할당 해제 */
+	struct page page;
+
+	page.va = pg_round_down(va);
+	
+	e = hash_find(&spt->hash, &page.hash_elem);
 
 	/* va와 대응하는 page 구조체 반환 */
 	return e != NULL ? hash_entry(e, struct page, hash_elem) : NULL;
@@ -200,7 +198,6 @@ vm_evict_frame(void)
 		struct page *page = list_entry(pe, struct page, f_elem);
 		swap_out(page);
 		page->frame = NULL;
-		list_remove(&page->f_elem);
 	}
 	list_remove(&victim->ft_elem);
 


### PR DESCRIPTION
- file-backed/anon swap out시 page list에서 제거
- file-backed/anon swap out 내부에서 참조하는 pml4 대상을 page owner로 수정
- anon destroy시 swap table bitmap 값 수정